### PR TITLE
Tests for unistd.h, and includes it if present

### DIFF
--- a/deps/premake/zlib.lua
+++ b/deps/premake/zlib.lua
@@ -15,6 +15,10 @@ function iw4of.zlib.includes()
 	defines {
 		"ZLIB_CONST",
 	}
+
+	if os.isfile("/usr/include/unistd.h") then
+		defines { "HAVE_UNISTD_H" }
+	end
 end
 
 function iw4of.zlib.project()


### PR DESCRIPTION
Upstream is configured to test for unistd.h and includes it if present. But since we're wrapping the meta build generation with Premake, we accidentally sidestepped this.