### PR TITLE
Change sizeof to evaluate type rather than expression

### DIFF
--- a/src/iw4-of/assets/asset_interfaces/iclipmap.cpp
+++ b/src/iw4-of/assets/asset_interfaces/iclipmap.cpp
@@ -14,16 +14,16 @@ namespace iw4of::interfaces
 {
 #define IW4X_CLIPMAP_VERSION 3
 
-    static_assert(sizeof native::ClipMaterial == 12);
-    static_assert(sizeof native::cbrushside_t == 8);
-    static_assert(sizeof native::cNode_t == 8);
-    static_assert(sizeof native::cLeaf_t == 40);
-    static_assert(sizeof native::cLeafBrushNode_s == 20);
-    static_assert(sizeof native::CollisionBorder == 28);
-    static_assert(sizeof native::CollisionPartition == 12);
-    static_assert(sizeof native::CollisionAabbTree == 32);
-    static_assert(sizeof native::cmodel_t == 68);
-    static_assert(sizeof native::SModelAabbNode == 28);
+    static_assert(sizeof (native::ClipMaterial) == 12);
+    static_assert(sizeof (native::cbrushside_t) == 8);
+    static_assert(sizeof (native::cNode_t) == 8);
+    static_assert(sizeof (native::cLeaf_t) == 40);
+    static_assert(sizeof (native::cLeafBrushNode_s) == 20);
+    static_assert(sizeof (native::CollisionBorder) == 28);
+    static_assert(sizeof (native::CollisionPartition) == 12);
+    static_assert(sizeof (native::CollisionAabbTree) == 32);
+    static_assert(sizeof (native::cmodel_t) == 68);
+    static_assert(sizeof (native::SModelAabbNode) == 28);
 
     std::filesystem::path iclipmap::get_file_name(const std::string& name) const
     {
@@ -948,9 +948,9 @@ namespace iw4of::interfaces
         // ENTITIES
         if (clip_map->mapEnts)
         {
-            static_assert(sizeof native::TriggerSlab == 20);
-            static_assert(sizeof native::TriggerModel == 8);
-            static_assert(sizeof native::TriggerHull == 32);
+            static_assert(sizeof (native::TriggerSlab) == 20);
+            static_assert(sizeof (native::TriggerModel) == 8);
+            static_assert(sizeof (native::TriggerHull) == 32);
 
             rapidjson::Value json_map_ents(rapidjson::kObjectType);
             const auto ents = clip_map->mapEnts;

--- a/src/iw4-of/assets/asset_interfaces/imaterial.cpp
+++ b/src/iw4-of/assets/asset_interfaces/imaterial.cpp
@@ -186,7 +186,7 @@ namespace iw4of::interfaces
             for (char i = 0; i < asset->constantCount; ++i)
             {
                 native::MaterialConstantDef constantDef;
-                std::memcpy(&constantDef, &asset->constantTable[i], sizeof native::MaterialConstantDef);
+                std::memcpy(&constantDef, &asset->constantTable[i], sizeof (native::MaterialConstantDef));
 
                 rapidjson::Value constantDefJson(rapidjson::kObjectType);
 

--- a/src/iw4-of/assets/asset_interfaces/iweapon.cpp
+++ b/src/iw4-of/assets/asset_interfaces/iweapon.cpp
@@ -1412,14 +1412,14 @@ namespace iw4of::interfaces
 
         if (original)
         {
-            std::memcpy(weapon, original, sizeof native::WeaponCompleteDef);
+            std::memcpy(weapon, original, sizeof (native::WeaponCompleteDef));
         }
 
         weapon->weapDef = local_allocator.allocate<native::WeaponDef>();
 
         if (original)
         {
-            std::memcpy(weapon->weapDef, original->weapDef, sizeof native::WeaponDef);
+            std::memcpy(weapon->weapDef, original->weapDef, sizeof (native::WeaponDef));
         }
 
         const rapidjson::Value* obj = nullptr;

--- a/src/iw4-of/assets/asset_interfaces/ixanimparts.cpp
+++ b/src/iw4-of/assets/asset_interfaces/ixanimparts.cpp
@@ -87,7 +87,7 @@ bool iw4of::interfaces::ixanimparts::write_internal(const native::XAssetHeader& 
     if (parts->deltaPart)
     {
         auto delta = parts->deltaPart;
-        static_assert(sizeof native::XAnimDeltaPart == 12);
+        static_assert(sizeof (native::XAnimDeltaPart) == 12);
 
         buffer.save_object(*delta);
         if (delta->trans)

--- a/src/iw4-of/game/structs.hpp
+++ b/src/iw4-of/game/structs.hpp
@@ -1127,7 +1127,7 @@ namespace iw4of::native
         PhysCollmap* physCollmap;
     };
 
-    static_assert(sizeof XModel == 304);
+    static_assert(sizeof (XModel) == 304);
 
     struct cStaticModel_t
     {


### PR DESCRIPTION
From https://en.cppreference.com/w/cpp/language/sizeof

Using sizeof without parentheses should evaluate the expression. MSVC behaves incorrectly when compiling under C++, while other compilers will return an error as expected.

https://developercommunity.visualstudio.com/t/sizeof-type-name-improperly-accepted-wit/10433628?q=limit+merge+type