### PR TITLE
Use __attribute__ without MSVC

### DIFF
--- a/src/iw4-of/game/structs.hpp
+++ b/src/iw4-of/game/structs.hpp
@@ -3408,7 +3408,7 @@ namespace iw4of::native
         NAMEOF(WEAPOVERLAYINTERFACE_TURRETSCOPE)
     };
 
-    struct __declspec(align(4)) WeaponDef
+    struct ATTR(align(4)) WeaponDef
     {
         const char* szOverlayName;
         XModel** gunXModel;

--- a/src/iw4-of/std_include.hpp
+++ b/src/iw4-of/std_include.hpp
@@ -26,6 +26,12 @@
     #undef min
 #endif
 
+#ifdef _MSC_VER
+  #define ATTR(...) __declspec((__VA_ARGS__))
+#else
+  #define ATTR(...) __attribute__((__VA_ARGS__))
+#endif
+
 #include <atomic>
 #include <chrono>
 #include <filesystem>


### PR DESCRIPTION
`__delspec` is a Microsoft-specific extension to the C++ language; if we're not using MSVC, use `__attribute__` instead.